### PR TITLE
Make sure phar:// includes aren't blocked by suhosin

### DIFF
--- a/stub.php
+++ b/stub.php
@@ -25,6 +25,16 @@ if (version_compare(LIBXML_DOTTED_VERSION, '2.6.20', '<')) {
     exit -1;
 }
 
+// Make sure phar:// includes are available
+if (extension_loaded('suhosin')) {
+    if (strpos(ini_get('suhosin.executor.include.whitelist'), 'phar') === false
+        || strpos(ini_get('suhosin.executor.include.blacklist'), 'phar') !== false
+    ) {
+        echo "Pyrus requires phar:// includes to be enabled.\n";
+        exit -1;
+    }
+}
+
 try {
     Phar::mapPhar();
 } catch (Exception $e) {


### PR DESCRIPTION
I grabbed a copy of pyrus.phar (version 2.0.0a3) today, and when executing it, there was no output at all. After further investigation, it seems that by default suhosin disables including files that use the `phar://` stream wrapper. Since there was no output or error messages, it took a while to track down what was going on.

I'm not sure whether or not it's appropriate to include this check, since suhosin isn't "part" of PHP, but given that it's enabled by default on debian/ubuntu, I think it's an issue a lot of users may encounter. Perhaps a note in the manual somewhere would be another (better?) solution.
