### PR TITLE
Allow per-channel settings

### DIFF
--- a/data/built-in-commands.xml
+++ b/data/built-in-commands.xml
@@ -417,6 +417,12 @@ based on the answers provided.</doc>
     <type><bool/></type>
     <doc>Manage plugin configuration only</doc>
    </option>
+   <option>
+    <name>channel</name>
+    <shortopt>c</shortopt>
+    <type><string/></type>
+    <doc>Set the value only for that specific channel</doc>
+   </option>
   </options>
   <arguments>
    <argument>
@@ -449,6 +455,12 @@ php pyrus.phar set download_dir /home/blah/downloads</doc>
     <shortopt>p</shortopt>
     <type><bool/></type>
     <doc>Get plugin configuration only</doc>
+   </option>
+   <option>
+     <name>channel</name>
+     <shortopt>c</shortopt>
+     <type><string/></type>
+     <doc>Get the value for a specific channel</doc>
    </option>
   </options>
   <arguments>

--- a/data/built-in-commands.xml
+++ b/data/built-in-commands.xml
@@ -458,6 +458,12 @@ user configuration settings.</doc>
     <type><bool/></type>
     <doc>Manage plugin configuration only</doc>
    </option>
+   <option>
+    <name>channel</name>
+    <shortopt>c</shortopt>
+    <type><string/></type>
+    <doc>Set the value only for that specific channel</doc>
+   </option>
   </options>
   <arguments>
    <argument>
@@ -490,6 +496,12 @@ php pyrus.phar set download_dir /home/blah/downloads</doc>
     <shortopt>p</shortopt>
     <type><bool/></type>
     <doc>Get plugin configuration only</doc>
+   </option>
+   <option>
+     <name>channel</name>
+     <shortopt>c</shortopt>
+     <type><string/></type>
+     <doc>Get the value for a specific channel</doc>
    </option>
   </options>
   <arguments>

--- a/src/Pyrus/ScriptFrontend/Commands.php
+++ b/src/Pyrus/ScriptFrontend/Commands.php
@@ -897,6 +897,11 @@ previous:
             $conf = \Pyrus\Config::singleton(\Pyrus\Config::current()->plugins_dir);
         }
 
+        if ($options['channel']) {
+            $oldDefaultChannel = $conf->default_channel;
+            $channel = $conf->channelregistry->get($options['channel'], false);
+            $conf->default_channel = $channel->name;
+        }
         if (
             in_array($args['variable'], $conf->uservars)
             || in_array($args['variable'], $conf->systemvars)
@@ -907,6 +912,9 @@ previous:
             exit(1);
         }
 
+        if ($options['channel']) {
+            $conf->default_channel = $oldDefaultChannel;
+        }
         if ($options['plugin']) {
             \Pyrus\Config::setCurrent($current->path);
         }
@@ -920,18 +928,27 @@ previous:
     function set($args, $options)
     {
         $conf = $current = \Pyrus\Config::current();
+        
         if ($options['plugin']) {
             $conf = \Pyrus\Config::singleton(\Pyrus\Config::current()->plugins_dir);
         }
+        if ($options['channel']) {
+            $oldDefaultChannel = $conf->default_channel;
+            $channel = $conf->channelregistry->get($options['channel'], false);
+            $conf->default_channel = $channel->name;
+        }
         if (in_array($args['variable'], $conf->uservars)) {
-            echo "Setting $args[variable] in " . $conf->userfile . "\n";
+            echo "Setting $args[variable] for channel " . $conf->default_channel . " in " . $conf->userfile . "\n";
             $conf->{$args['variable']} = $args['value'];
         } elseif (in_array($args['variable'], $conf->systemvars)) {
-            echo "Setting $args[variable] in system paths\n";
+            echo "Setting $args[variable] for channel " . $conf->default_channel . " in system paths\n";
             $conf->{$args['variable']} = $args['value'];
         } else {
             echo "Unknown config variable: $args[variable]\n";
             exit(1);
+        }
+        if ($options['channel']) {
+            $conf->default_channel = $oldDefaultChannel;
         }
         $conf->saveConfig();
         if ($options['plugin']) {

--- a/src/Pyrus/ScriptFrontend/Commands.php
+++ b/src/Pyrus/ScriptFrontend/Commands.php
@@ -939,7 +939,7 @@ previous:
                 $conf->default_channel = $channel->name;
             }
 
-            echo "Setting $args[variable] for channel " . $conf->default_channel . " in " . $conf->userfile . "\n";
+            echo "Setting $args[variable] for " . $conf->default_channel . " in " . $conf->userfile . "\n";
             $conf->{$args['variable']} = $args['value'];
 
             if ($options['channel']) {
@@ -949,7 +949,7 @@ previous:
             echo "Setting $args[variable] in " . $conf->userfile . "\n";
             $conf->{$args['variable']} = $args['value'];
         } elseif (in_array($args['variable'], $conf->systemvars)) {
-            echo "Setting $args[variable] for channel " . $conf->default_channel . " in system paths\n";
+            echo "Setting $args[variable] in system paths\n";
             $conf->{$args['variable']} = $args['value'];
         } else {
             echo "Unknown config variable: $args[variable]\n";

--- a/src/Pyrus/ScriptFrontend/Commands.php
+++ b/src/Pyrus/ScriptFrontend/Commands.php
@@ -928,27 +928,32 @@ previous:
     function set($args, $options)
     {
         $conf = $current = \Pyrus\Config::current();
-        
+
         if ($options['plugin']) {
             $conf = \Pyrus\Config::singleton(\Pyrus\Config::current()->plugins_dir);
         }
-        if ($options['channel']) {
-            $oldDefaultChannel = $conf->default_channel;
-            $channel = $conf->channelregistry->get($options['channel'], false);
-            $conf->default_channel = $channel->name;
-        }
-        if (in_array($args['variable'], $conf->uservars)) {
+        if (in_array($args['variable'], $conf->channelvars)) {
+            if ($options['channel']) {
+                $oldDefaultChannel = $conf->default_channel;
+                $channel = $conf->channelregistry->get($options['channel'], false);
+                $conf->default_channel = $channel->name;
+            }
+
             echo "Setting $args[variable] for channel " . $conf->default_channel . " in " . $conf->userfile . "\n";
             $conf->{$args['variable']} = $args['value'];
+
+            if ($options['channel']) {
+                $conf->default_channel = $oldDefaultChannel;
+            }
+        } elseif (in_array($args['variable'], $conf->uservars)) {
+            echo "Setting $args[variable] in " . $conf->userfile . "\n";
+            $conf->{$args['variable']} = $args['value'];
         } elseif (in_array($args['variable'], $conf->systemvars)) {
-            echo "Setting $args[variable] for channel " . $conf->default_channel . " in system paths\n";
+            echo "Setting $args[variable] in system paths\n";
             $conf->{$args['variable']} = $args['value'];
         } else {
             echo "Unknown config variable: $args[variable]\n";
             exit(1);
-        }
-        if ($options['channel']) {
-            $conf->default_channel = $oldDefaultChannel;
         }
         $conf->saveConfig();
         if ($options['plugin']) {

--- a/src/Pyrus/ScriptFrontend/Commands.php
+++ b/src/Pyrus/ScriptFrontend/Commands.php
@@ -955,9 +955,6 @@ previous:
             echo "Unknown config variable: $args[variable]\n";
             exit(1);
         }
-        if ($options['channel']) {
-            $conf->default_channel = $oldDefaultChannel;
-        }
         $conf->saveConfig();
         if ($options['plugin']) {
             \Pyrus\Config::setCurrent($current->path);

--- a/src/Pyrus/ScriptFrontend/Commands.php
+++ b/src/Pyrus/ScriptFrontend/Commands.php
@@ -868,12 +868,20 @@ previous:
         if ($options['plugin']) {
             $conf = \Pyrus\Config::singleton(\Pyrus\Config::current()->plugins_dir);
         }
+        if ($options['channel']) {
+            $oldDefaultChannel = $conf->default_channel;
+            $channel = $conf->channelregistry->get($options['channel'], false);
+            $conf->default_channel = $channel->name;
+        }
         if (in_array($args['variable'], $conf->uservars)
             || in_array($args['variable'], $conf->systemvars)) {
             echo $conf->{$args['variable']} . PHP_EOL;
         } else {
             echo "Unknown config variable: $args[variable]\n";
             exit(1);
+        }
+        if ($options['channel']) {
+            $conf->default_channel = $oldDefaultChannel;
         }
         if ($options['plugin']) {
             \Pyrus\Config::setCurrent($current->path);
@@ -888,18 +896,27 @@ previous:
     function set($args, $options)
     {
         $conf = $current = \Pyrus\Config::current();
+        
         if ($options['plugin']) {
             $conf = \Pyrus\Config::singleton(\Pyrus\Config::current()->plugins_dir);
         }
+        if ($options['channel']) {
+            $oldDefaultChannel = $conf->default_channel;
+            $channel = $conf->channelregistry->get($options['channel'], false);
+            $conf->default_channel = $channel->name;
+        }
         if (in_array($args['variable'], $conf->uservars)) {
-            echo "Setting $args[variable] in " . $conf->userfile . "\n";
+            echo "Setting $args[variable] for channel " . $conf->default_channel . " in " . $conf->userfile . "\n";
             $conf->{$args['variable']} = $args['value'];
         } elseif (in_array($args['variable'], $conf->systemvars)) {
-            echo "Setting $args[variable] in system paths\n";
+            echo "Setting $args[variable] for channel " . $conf->default_channel . " in system paths\n";
             $conf->{$args['variable']} = $args['value'];
         } else {
             echo "Unknown config variable: $args[variable]\n";
             exit(1);
+        }
+        if ($options['channel']) {
+            $conf->default_channel = $oldDefaultChannel;
         }
         $conf->saveConfig();
         if ($options['plugin']) {

--- a/tests/ScriptFrontend/Commands/set2.phpt
+++ b/tests/ScriptFrontend/Commands/set2.phpt
@@ -17,7 +17,7 @@ $contents = ob_get_contents();
 ob_end_clean();
 $help1 = 'Using PEAR installation found at ' . TESTDIR . "\n";
 $d = DIRECTORY_SEPARATOR;
-$help2 = "Setting handle for channel pecl.php.net in " . TESTDIR . "/plugins/foo.xml\n";
+$help2 = "Setting handle for pecl.php.net in " . TESTDIR . "/plugins/foo.xml\n";
 
 $test->assertEquals($help1 . $help2,
                     $contents,

--- a/tests/ScriptFrontend/Commands/set2.phpt
+++ b/tests/ScriptFrontend/Commands/set2.phpt
@@ -1,0 +1,36 @@
+--TEST--
+\Pyrus\ScriptFrontend\Commands::set() on specific channel
+--FILE--
+<?php
+require __DIR__ . '/setup.php.inc';
+set_include_path(TESTDIR);
+$a = \Pyrus\Config::singleton(TESTDIR, TESTDIR . '/plugins/pearconfig.xml');
+$a->ext_dir = TESTDIR . '/ext';
+$a->bin_dir = TESTDIR . '/bin';
+file_put_contents(TESTDIR . '/plugins/pearconfig.xml', '<pearconfig version="1.0"></pearconfig>');
+
+ob_start();
+$cli = new test_scriptfrontend();
+$cli->run($args = array (0 => 'set', '-c', 'pecl.php.net', 'handle', 'poo'));
+
+$contents = ob_get_contents();
+ob_end_clean();
+$help1 = 'Using PEAR installation found at ' . TESTDIR . "\n";
+$d = DIRECTORY_SEPARATOR;
+$help2 = "Setting handle for channel pecl.php.net in " . TESTDIR . "/plugins/foo.xml\n";
+
+$test->assertEquals($help1 . $help2,
+                    $contents,
+                    'set output');
+\Pyrus\Config::current()->default_channel = 'pecl.php.net';
+$test->assertEquals('poo', \Pyrus\Config::current()->handle, 'confirm value changed');
+$a = simplexml_load_file(TESTDIR . '/plugins/foo.xml');
+$test->assertEquals('poo', (string)$a->handle[0]->peclDOTphpDOTnet, 'confirm value saved');
+?>
+===DONE===
+--CLEAN--
+<?php
+include __DIR__ . '/../../clean.php.inc';
+?>
+--EXPECT--
+===DONE===


### PR DESCRIPTION
This commit makes it possible to get/set a setting for a specific PEAR
channel. This is done by adding a new option to the get/set commands
(-c/--channel) which can be used to pass the name of the PEAR channel
to operate on. Both fullnames (eg. "pear.php.net") and aliases (eg. "pear")
are supported.
See pyrus/Pyrus#7
