### PR TITLE
Make the progressbar vanish when done d/ling

### DIFF
--- a/src/Pyrus/DownloadProgressListener.php
+++ b/src/Pyrus/DownloadProgressListener.php
@@ -43,8 +43,13 @@ class DownloadProgressListener extends \PEAR2\HTTP\Request\Listener
     {
         switch ($event) {
             case 'connect' :
-                $this->preview = "Connected...\n";
+                $this->preview = "";
                 $this->done = false;
+                break;
+            case 'disconnect' :
+                // Length of meter "[==...=>]" + " 100% (/ kb)" + twice the filesize.
+                $length = 103 + 12 + strlen(sprintf("%2d", $this->filesize/1024)) * 2;
+                Logger::log(0, str_repeat("\010", $length) . "\r");
                 break;
             case 'redirect' :
                 $this->preview .= 'Redirected to ' . $data . "\n";
@@ -59,7 +64,7 @@ class DownloadProgressListener extends \PEAR2\HTTP\Request\Listener
                 // borrowed from fetch.php in php-src
                 if ($data > 0) {
                     if ($this->preview) {
-                        Logger::log(0, $this->preview);
+                        Logger::log(0, rtrim($this->preview, "\n"));
                         $this->preview = '';
                     }
 

--- a/vendor/php/PEAR2/HTTP/Request/Adapter/Curl.php
+++ b/vendor/php/PEAR2/HTTP/Request/Adapter/Curl.php
@@ -94,6 +94,7 @@ class Curl extends Request\Adapter
         if ($this->fp !== false) {
             fclose($this->fp);
         }
+        $this->_notify('disconnect');
 
         $details = $this->uri->toArray();
 

--- a/vendor/php/PEAR2/HTTP/Request/Adapter/Http.php
+++ b/vendor/php/PEAR2/HTTP/Request/Adapter/Http.php
@@ -53,6 +53,7 @@ class Http extends Request\Adapter
         }
 
         $request->send();
+        $this->_notify('disconnect');
         $response = $request->getResponseMessage();
         $body = $response->getBody();
 

--- a/vendor/php/PEAR2/HTTP/Request/Listener.php
+++ b/vendor/php/PEAR2/HTTP/Request/Listener.php
@@ -113,4 +113,3 @@ class Listener
     }
 }
 ?>
-


### PR DESCRIPTION
See pyrus/Pyrus#2 for more information.
The progress bar now correctly vanishes at the end of each download.
I also removed some of the extra line feeds so the output now looks
somewhat more compact.

Reproduced below is an example of a complete session.

<pre>
$ ./scripts/pyrus i --optionaldeps pear/Console_Table
Using PEAR installation found at /var/local/buildbot/pear
Downloading pear.php.net/Console_Table
Downloading pear.php.net/Console_Color
Installed pear.php.net/Console_Table-1.1.4
Installed pear.php.net/Console_Color-1.0.3
</pre>
