### PR TITLE
Check MIME type of signature files

### DIFF
--- a/src/Pyrus/Channel/RemotePackage.php
+++ b/src/Pyrus/Channel/RemotePackage.php
@@ -348,8 +348,11 @@ class RemotePackage extends \Pyrus\PackageFile\v2 implements \ArrayAccess, \Iter
             // try to download openssl x509 signature certificate for our release
             try {
                 $cert = \Pyrus\Main::download($url . '.pem');
-                $cert = $cert->body;
-                $certdownloaded = true;
+                // ensure this is supposed to be a valid certificate
+                if ($cert->headers['Content-Type'] == 'application/x-x509-ca-cert') {
+                    $cert = $cert->body;
+                    $certdownloaded = true;
+                }
             } catch (\Pyrus\HTTPException $e) {
                 // file does not exist, ignore
             }
@@ -412,22 +415,12 @@ class RemotePackage extends \Pyrus\PackageFile\v2 implements \ArrayAccess, \Iter
 
                 $ret = new \Pyrus\Package\Remote($url . $ext);
                 return $ret;
-            } catch (\Pyrus\HTTPException $e) {
-                if ($certdownloaded && file_exists($pubkey)) {
-                    unlink($pubkey);
-                }
-
-                $errs->E_ERROR[] = $e;
             } catch (\Exception $e) {
                 if ($certdownloaded && file_exists($pubkey)) {
                     unlink($pubkey);
                 }
 
                 $errs->E_ERROR[] = $e;
-                throw new \Pyrus\Package\Exception(
-                    'Invalid abstract package ' .
-                    $this->channel . '/' .
-                    $this->name, $errs);
             }
         }
 


### PR DESCRIPTION
When attempting to check a package's release against its signature, a
check should first be made against the signature's MIME type, to avoid
throwing exceptions ("releasing maintainer's certificate is not a
certificate") when something else was returned by the server (like an
HTML page).

Also, don't throw an exception immediately when the downloaded package
could not be parsed. Again, the server may have returned something
completely different. We wait until all attempts (using different file
extensions) to download a valid package have failed before bailing out.

See pyrus/Pyrus#32 for more information.
