### PR TITLE
Fixed error message error

### DIFF
--- a/src/Pyrus/Package/Remote.php
+++ b/src/Pyrus/Package/Remote.php
@@ -160,7 +160,7 @@ class Remote extends \Pyrus\Package
         if ($internal->channel != $this->channel) {
             throw new Exception('SECURITY ERROR: package is claiming to be from ' .
                                 'channel ' . $internal->channel . ', but we are ' .
-                                'channel ' . $this->name);
+                                'channel ' . $this->channel);
         }
 
         $internal->setFrom($this->internal);


### PR DESCRIPTION
When there is error: "package is claiming to be from channel xxxx, but we are channel xxx.", it should use channel name instead of package name.
