### PR TITLE
DOMDocument::schemaValidate doesn't support phar:// stream

### DIFF
--- a/src/Pyrus/PackageFile/v2/Validator.php
+++ b/src/Pyrus/PackageFile/v2/Validator.php
@@ -95,9 +95,11 @@ class Validator
                 }
                 $tmpschema = $temp . DIRECTORY_SEPARATOR . basename($schema);
                 copy($schema, $tmpschema);
+                $dom->schemaValidate($tmpschema);
+            } else {
+                $dom->schemaValidate($schema);
             }
 
-            $dom->schemaValidate($tmpschema);
             $causes = array();
             foreach (libxml_get_errors() as $error) {
                 $this->errors->E_ERROR[] = new \Pyrus\PackageFile\Exception("Line " .

--- a/src/Pyrus/PackageFile/v2/Validator.php
+++ b/src/Pyrus/PackageFile/v2/Validator.php
@@ -87,7 +87,17 @@ class Validator
                     $schema = dirname(dirname(dirname(dirname(__DIR__)))) . '/data/package-2.0.xsd';
                 }
             }
-            $dom->schemaValidate($schema);
+            // libxml can't process these from within a phar (pity)
+            if (strpos($schema, 'phar://') === 0) {
+                if (!file_exists($temp = \Pyrus\Config::current()->temp_dir . DIRECTORY_SEPARATOR . 'schema')
+                ) {
+                    mkdir($temp, 0755, true);
+                }
+                $tmpschema = $temp . DIRECTORY_SEPARATOR . basename($schema);
+                copy($schema, $tmpschema);
+            }
+
+            $dom->schemaValidate($tmpschema);
             $causes = array();
             foreach (libxml_get_errors() as $error) {
                 $this->errors->E_ERROR[] = new \Pyrus\PackageFile\Exception("Line " .


### PR DESCRIPTION
http://www.php.net/manual/en/domdocument.schemavalidate.php doesn't support php specific streams as the filename is just passed to the libxml function:
http://lxr.php.net/opengrok/xref/PHP_5_3/ext/dom/document.c#_dom_get_valid_file_path

this means, that the current schemaValidate call ends up looking for "phar:///home/tyrael/pyrus.phar/PEAR2_Pyrus-2.0.0a3/data/pear2.php.net/PEAR2_Pyrus/package-2.1.xsd" on the filesystem, which obviously won't be there.

I've came up with a solution similar to https://github.com/pyrus/Pyrus/blob/master/src/Pyrus/Channel/RemotePackage.php#L212

after this modification (and passing the package name to the make command, and setting up the CREDITS in the expected format, and creating the RELEASE-X.Y.Z) pyrus successfully created the package.xml.
