### PR TITLE
Regression: $extrafiles does not accept strings anymore

### DIFF
--- a/src/Pyrus/Package/Creator.php
+++ b/src/Pyrus/Package/Creator.php
@@ -320,23 +320,24 @@ class Creator
     function addExtraFiles($extrafiles)
     {
         foreach ($extrafiles as $path => $filename) {
-            if (!is_object($filename)) {
+            if (is_object($filename)) {
+                if ($filename instanceof \Pyrus\PackageInterface) {
+                    foreach ($filename->packagingcontents as $path => $info) {
+                        foreach ($this->_creators as $creator) {
+                            $creator->mkdir(dirname($this->prepend . '/' . $path));
+                            $fp = $filename->getFileContents($info['attribs']['name'], true);
+                            $creator->addFile($this->prepend . '/' . $path, $fp);
+                            fclose($fp);
+                        }
+                    }
+                    continue;
+                }
+
                 throw new Exception('Invalid extra file object, must be ' .
                                         'a \Pyrus\Package object');
             }
 
-            if ($filename instanceof \Pyrus\PackageInterface) {
-                foreach ($filename->packagingcontents as $path => $info) {
-                    foreach ($this->_creators as $creator) {
-                        $creator->mkdir(dirname($this->prepend . '/' . $path));
-                        $fp = $filename->getFileContents($info['attribs']['name'], true);
-                        $creator->addFile($this->prepend . '/' . $path, $fp);
-                        fclose($fp);
-                    }
-                }
-                continue;
-            }
-
+            // $extrafiles may also contain string => string entries.
             $path = str_replace(array('\\', '//'), '/', $path);
             if ($path[0] === '/' ||
                   (strlen($path) > 2 && ($path[1] === ':' && $path[2] == '/'))) {

--- a/tests/Package/extrafiles.phpt
+++ b/tests/Package/extrafiles.phpt
@@ -1,0 +1,46 @@
+--TEST--
+\Pyrus\Package\Creator: extrafiles may contain strings (#71)
+--FILE--
+<?php
+include __DIR__ . '/setup.php.inc';
+$pf = new \Pyrus\PackageFile\v2;
+
+$pf->name = 'testing2';
+$pf->channel = 'pear2.php.net';
+$pf->summary = 'testing';
+$pf->description = 'hi description';
+$pf->notes = 'my notes';
+$pf->maintainer['cellog']->role('lead')->email('cellog@php.net')->active('yes')->name('Greg Beaver');
+$pf->setPackagefile(TESTDIR . '/package.xml');
+
+$package = new \Pyrus\Package(false);
+$xmlcontainer = new \Pyrus\PackageFile($pf);
+$xml = new \Pyrus\Package\Xml(TESTDIR . '/package.xml', $package, $xmlcontainer);
+$package->setInternalPackage($xml);
+
+$vendorDir = __DIR__ . '/../../vendor/php/PEAR2/';
+$outfile = $package->name.'-'.$package->version['release'];
+$a = new \Pyrus\Package\Creator(
+    array(
+        new \Pyrus\Developer\Creator\Phar(
+            $outfile.'.tgz',
+            false,
+            Phar::TAR, Phar::GZ
+        )
+    ),
+    $vendorDir,
+    $vendorDir,
+    $vendorDir
+);
+
+// Try to include the current file as part of the test suite.
+$a->render($package, array('tests/extrafiles.phpt' => __FILE__));
+
+?>
+===DONE===
+--CLEAN--
+<?php
+include __DIR__ . '/../clean.php.inc';
+?>
+--EXPECT--
+===DONE===


### PR DESCRIPTION
These commits partly revert the change made in efc3a883cbcf5512d03602e9aa8dcdc42bbbe620 to allow $extrafiles to handle strings again and add a PHPT test.
This fixes issue pyrus/Pyrus#71.

This change is important because the current manual for Pyrus suggests to add extra files that way [1] and some packages already depend on that behaviour [2].

[1] http://pear.php.net/manual/en/pyrus.commands.package.php#pyrus.commands.package.extrasetup
[2] https://github.com/pyrus/Pyrus/blob/master/tests/Mocks/SimpleChannelServer/makepackage.php
