### PR TITLE
Use space instead of \n for the channel schemaLocation list

### DIFF
--- a/src/Pyrus/ChannelFile/v1.php
+++ b/src/Pyrus/ChannelFile/v1.php
@@ -46,8 +46,7 @@ class v1 extends \Pyrus\ChannelFile implements \Pyrus\ChannelFileInterface
             'version' => '1.0',
             'xmlns' => 'http://pear.php.net/channel-1.0',
             'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
-            'xsi:schemaLocation' => 'http://pear.php.net/channel-1.0
-http://pear.php.net/dtd/channel-1.0.xsd'
+            'xsi:schemaLocation' => 'http://pear.php.net/channel-1.0 http://pear.php.net/dtd/channel-1.0.xsd'
         );
 
     private $_xml;


### PR DESCRIPTION
The \XMLWriter class will convert attributes with newlines into 
&#10; and &#13;. To work-around this issue, Pyrus\XMLWriter removes
newline characters which affects the channel.xml root attributes.
