### PR TITLE
Case-insensitive comparison of MIME type.

### DIFF
--- a/src/Pyrus/Channel/RemotePackage.php
+++ b/src/Pyrus/Channel/RemotePackage.php
@@ -348,10 +348,16 @@ class RemotePackage extends \Pyrus\PackageFile\v2 implements \ArrayAccess, \Iter
             // try to download openssl x509 signature certificate for our release
             try {
                 $cert = \Pyrus\Main::download($url . '.pem');
+
                 // ensure this is supposed to be a valid certificate
-                if ($cert->headers['Content-Type'] == 'application/x-x509-ca-cert') {
-                    $cert = $cert->body;
-                    $certdownloaded = true;
+                $contentType = $cert->headers['content-type'];
+                if (null !== $contentType) {
+                    // ignore parameters during comparison.
+                    $contentType = (string) substr($contentType, 0, strcspn($contentType, ';'));
+                    if (!strcasecmp($contentType, 'application/x-x509-ca-cert')) {
+                        $cert = $cert->body;
+                        $certdownloaded = true;
+                    }
                 }
             } catch (\Pyrus\HTTPException $e) {
                 // file does not exist, ignore

--- a/tests/Mocks/Internet.php
+++ b/tests/Mocks/Internet.php
@@ -87,6 +87,9 @@ class Internet_Adapter extends \PEAR2\HTTP\Request\Adapter
                 case 'txt' :
                     $headers['content-type'] = 'text/plain';
                     break;
+                case 'pem' :
+                    $headers['content-type'] = 'application/x-x509-ca-cert';
+                    break;
                 default :
                     $headers['content-type'] = 'application/octet-stream';
             }


### PR DESCRIPTION
Takes cweiske's remarks regarding headers/MIME types case-insensitivity
into account (see https://github.com/fpoirotte/Pyrus/commit/316687b33ed23fb318110a85c8b3682d3cec6b3c#commitcomment-1040541).
The code does not rely on MIME_Type to help minimize the
number of dependencies required by Pyrus.

Adapts mocks so that PEM files receive the proper file content.
Makes two additional unit tests pass.
