### PR TITLE
Add method stub to avoid fatal error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+before_script: pyrus install -p pyrus.net/Pyrus_Developer-alpha
+script: pyrus run-phpt -r tests
+

--- a/src/Pyrus/PackageFile/v2.php
+++ b/src/Pyrus/PackageFile/v2.php
@@ -210,6 +210,11 @@ class v2 implements \Pyrus\PackageFileInterface
         $this->_archiveFile = $archive ? $archive : $file;
     }
 
+    function hasConcreteVersion()
+    {
+        return false;
+    }
+
     function getReleaseToInstall($var, $reset = false)
     {
         if (!$reset && isset($this->releaseIndex)) {


### PR DESCRIPTION
For some reason, code expects a Pyrus\PackageFile\v2 to be isRemote(), and causes this error.

Perhaps it's instantiated with $forceRemote for some odd reason? _shrug_.

Anyway, this paves over the problem a little bit.
