### PR TITLE
Resolved one failed test (23 to go)

### DIFF
--- a/scripts/pyrus
+++ b/scripts/pyrus
@@ -50,4 +50,8 @@ require_once $autoload;
 
 $frontend = new \Pyrus\ScriptFrontend\Commands;
 @array_shift($_SERVER['argv']);
-$frontend->run($_SERVER['argv']);
+$exitCode = $frontend->run($_SERVER['argv']);
+if (null === $exitCode || !is_numeric($exitCode)) {
+    $exitCode = (int) $exitCode;
+}
+exit($exitCode);

--- a/src/Pyrus/ScriptFrontend/Commands.php
+++ b/src/Pyrus/ScriptFrontend/Commands.php
@@ -267,7 +267,7 @@ class Commands implements \Pyrus\LogInterface
      *
      * @param array $args An array of command line arguments.
      *
-     * @return void
+     * @return int
      */
     function run($args)
     {
@@ -310,7 +310,7 @@ class Commands implements \Pyrus\LogInterface
                     }
                 } else {
                     $class = new $info['class'];
-                    exit((int)!$class->{$info['function']}($this, $result->command->args, $result->command->options));
+                    return (int)!$class->{$info['function']}($this, $result->command->args, $result->command->options);
                 }
             } else {
                 $this->help(array('command' => isset($args[0]) ? $args[0] : null));


### PR DESCRIPTION
Bugfix: fix for regression introduced in ca074ae
Change: ->run() should (!) always return an exit code, we exit() in the wrapper

Related ticket: #105
