### PR TITLE
Fixes two test failures (re: #105):

### DIFF
--- a/src/Pyrus/AtomicFileTransaction/Transaction.php
+++ b/src/Pyrus/AtomicFileTransaction/Transaction.php
@@ -143,7 +143,7 @@ class Transaction extends Transaction\TwoStage
                 throw new IOException('Unable to open ' . $relativePath . ' for writing in ' . $this->journalPath);
             }
 
-            if (false === stream_copy_to_stream($contents, $fp)) {
+            if (0 == stream_copy_to_stream($contents, $fp)) {
                 fclose($fp);
                 throw new IOException('Unable to copy to ' . $relativePath . ' in ' . $this->journalPath);
             }


### PR DESCRIPTION
- stream_copy_stream() never returns false but 0 (when nothing was copied)
- all credit to @saltybeagle (Brett Bieber)
