### PR TITLE
Class docblock fix

### DIFF
--- a/src/Pyrus/AtomicFileTransaction/MultiException.php
+++ b/src/Pyrus/AtomicFileTransaction/MultiException.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\AtomicFileTransaction;
+
 /**
  * Exception for atomic file transaction mechanism
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\AtomicFileTransaction;
 class MultiException extends \PEAR2\Exception implements Exception {}

--- a/src/Pyrus/Channel.php
+++ b/src/Pyrus/Channel.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base class for Pyrus.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Channel implements \Pyrus\ChannelInterface
 {
     protected $internal;

--- a/src/Pyrus/Channel/Exception.php
+++ b/src/Pyrus/Channel/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Channel;
+
 /**
  * Exception for channels
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Channel;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Channel/RemoteCategories.php
+++ b/src/Pyrus/Channel/RemoteCategories.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Channel;
+
 /**
  * Remote REST iteration handler for category listing
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Channel;
 class RemoteCategories implements \ArrayAccess, \Iterator
 {
     protected $parent;

--- a/src/Pyrus/Channel/RemoteCategory.php
+++ b/src/Pyrus/Channel/RemoteCategory.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Channel;
+
 /**
  * Remote REST iteration handler
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Channel;
 class RemoteCategory implements \ArrayAccess, \Iterator, \Countable
 {
     protected $parent;

--- a/src/Pyrus/Channel/RemoteMaintainers.php
+++ b/src/Pyrus/Channel/RemoteMaintainers.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Channel;
+
 /**
  * Remote REST iteration handler for maitainer listing
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Channel;
 class RemoteMaintainers implements \ArrayAccess, \Iterator
 {
     protected $parent;

--- a/src/Pyrus/Channel/RemotePackages.php
+++ b/src/Pyrus/Channel/RemotePackages.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Channel;
+
 /**
  * Remote REST iteration handler for package listing
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Channel;
 class RemotePackages implements \ArrayAccess, \Iterator
 {
     protected $parent;

--- a/src/Pyrus/ChannelFile.php
+++ b/src/Pyrus/ChannelFile.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base class for a PEAR2 package file
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class ChannelFile implements \Pyrus\ChannelFileInterface
 {
     protected $info;

--- a/src/Pyrus/ChannelFile/v1.php
+++ b/src/Pyrus/ChannelFile/v1.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelFile;
+
 /**
  * Base class for a PEAR channel.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelFile;
 class v1 extends \Pyrus\ChannelFile implements \Pyrus\ChannelFileInterface
 {
     /**

--- a/src/Pyrus/ChannelRegistry.php
+++ b/src/Pyrus/ChannelRegistry.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base class for Pyrus.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class ChannelRegistry implements \ArrayAccess, \IteratorAggregate, \Pyrus\ChannelRegistryInterface
 {
     /**

--- a/src/Pyrus/ChannelRegistry/Base.php
+++ b/src/Pyrus/ChannelRegistry/Base.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry;
+
 /**
  * Base class for Pyrus managed channel registries
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry;
 abstract class Base implements \Pyrus\ChannelRegistryInterface, \Iterator
 {
     protected $path;

--- a/src/Pyrus/ChannelRegistry/Channel.php
+++ b/src/Pyrus/ChannelRegistry/Channel.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry;
+
 /**
  * A class that represents individual channels within a channel registry
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry;
 class Channel extends \Pyrus\ChannelFile\v1 implements \Pyrus\ChannelInterface
 {
     private $_parent;

--- a/src/Pyrus/ChannelRegistry/Exception.php
+++ b/src/Pyrus/ChannelRegistry/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry;
+
 /**
  * Base class for Exceptions with a Pyrus channel registry.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry;
 class Exception extends \PEAR2\Exception
 {
 }

--- a/src/Pyrus/ChannelRegistry/Mirror/Sqlite3.php
+++ b/src/Pyrus/ChannelRegistry/Mirror/Sqlite3.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry\Mirror;
+
 /**
  * Represents a mirror within a Sqlite3 channel registry.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry\Mirror;
 class Sqlite3 extends \Pyrus\ChannelRegistry\Sqlite3
     implements \Pyrus\Channel\MirrorInterface
 {

--- a/src/Pyrus/ChannelRegistry/Mirror/Xml.php
+++ b/src/Pyrus/ChannelRegistry/Mirror/Xml.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry\Mirror;
+
 /**
  * A class for handling mirrors within an xml based channel registry.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry\Mirror;
 class Xml extends \Pyrus\ChannelFile\v1\Mirror
 {
     private $_parent;

--- a/src/Pyrus/ChannelRegistry/ParseException.php
+++ b/src/Pyrus/ChannelRegistry/ParseException.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry;
+
 /**
  * Base class for Exceptions when parsing channel registry.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry;
 class ParseException extends \PEAR2\Exception
 {
     public $why;

--- a/src/Pyrus/ChannelRegistry/Pear1.php
+++ b/src/Pyrus/ChannelRegistry/Pear1.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ChannelRegistry;
+
 /**
  * This is the central registry, that is used for all installer options,
  * stored in .reg files for PEAR 1 compatibility
@@ -23,7 +25,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ChannelRegistry;
 class Pear1 extends Base
 {
     private $_channelPath;

--- a/src/Pyrus/Config/Exception.php
+++ b/src/Pyrus/Config/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Config;
+
 /**
  * Exception class for Pyrus configuration
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Config;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Config/Snapshot.php
+++ b/src/Pyrus/Config/Snapshot.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Config;
+
 /**
  * Pyrus's master configuration manager
  *
@@ -38,7 +40,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Config;
 class Snapshot extends \Pyrus\Config
 {
     /**

--- a/src/Pyrus/DER.php
+++ b/src/Pyrus/DER.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Implements Distinguished Encoding Rules serialization and unserialization.
  *
@@ -27,7 +29,6 @@
  * @link      https://github.com/pyrus/Pyrus
  * @link      http://www.oss.com/asn1/dubuisson.html
  */
-namespace Pyrus;
 class DER implements \ArrayAccess
 {
     const SEQUENCE = 0x30;

--- a/src/Pyrus/DER/BMPString.php
+++ b/src/Pyrus/DER/BMPString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule BMPString
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class BMPString extends String
 {
     const TAG = 0x1E;

--- a/src/Pyrus/DER/BitString.php
+++ b/src/Pyrus/DER/BitString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Bit String
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class BitString extends \Pyrus\DER
 {
     const TAG = 0x03;

--- a/src/Pyrus/DER/Boolean.php
+++ b/src/Pyrus/DER/Boolean.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule boolean value
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Boolean extends \Pyrus\DER
 {
     const TAG = 0x01;

--- a/src/Pyrus/DER/Choice.php
+++ b/src/Pyrus/DER/Choice.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Context-sensitive abstract Choice
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Choice extends Sequence
 {
 }

--- a/src/Pyrus/DER/Constructed.php
+++ b/src/Pyrus/DER/Constructed.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IA5String
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 abstract class Constructed extends \Pyrus\DER
 {
     function parse($data, $location)

--- a/src/Pyrus/DER/Enumerated.php
+++ b/src/Pyrus/DER/Enumerated.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Integer
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Enumerated extends \Pyrus\DER\Integer
 {
     const TAG = 0x0A;

--- a/src/Pyrus/DER/Exception.php
+++ b/src/Pyrus/DER/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Exception when DER values are not representable
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Exception extends \PEAR2\Exception
 {
     

--- a/src/Pyrus/DER/External.php
+++ b/src/Pyrus/DER/External.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule External
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class External extends \Pyrus\DER
 {
     const TAG = 0x08;

--- a/src/Pyrus/DER/GeneralizedTime.php
+++ b/src/Pyrus/DER/GeneralizedTime.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Octet String
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class GeneralizedTime extends UTCTime
 {
     const TAG = 0x18;

--- a/src/Pyrus/DER/IA5String.php
+++ b/src/Pyrus/DER/IA5String.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IA5String
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class IA5String extends String
 {
     const TAG = 0x16;

--- a/src/Pyrus/DER/Integer.php
+++ b/src/Pyrus/DER/Integer.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Integer
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Integer extends \Pyrus\DER
 {
     const TAG = 0x02;

--- a/src/Pyrus/DER/Null.php
+++ b/src/Pyrus/DER/Null.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Null value
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Null extends \Pyrus\DER
 {
     const TAG = 0x05;

--- a/src/Pyrus/DER/NumericString.php
+++ b/src/Pyrus/DER/NumericString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IA5String
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class NumericString extends String
 {
     const TAG = 0x12;

--- a/src/Pyrus/DER/OCSPRequest.php
+++ b/src/Pyrus/DER/OCSPRequest.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IASN.1 schema
  *
@@ -24,7 +26,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class OCSPRequest extends \Pyrus\DER
 {
     protected function __construct($developerCert)

--- a/src/Pyrus/DER/ObjectIdentifier.php
+++ b/src/Pyrus/DER/ObjectIdentifier.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Object identifier
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class ObjectIdentifier extends \Pyrus\DER
 {
     const TAG = 0x06;

--- a/src/Pyrus/DER/OctetString.php
+++ b/src/Pyrus/DER/OctetString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Octet String
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class OctetString extends \Pyrus\DER
 {
     const TAG = 0x04;

--- a/src/Pyrus/DER/Parser.php
+++ b/src/Pyrus/DER/Parser.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Parses a Distinguished Encoding Rule binary string into a DER object
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Parser
 {
     

--- a/src/Pyrus/DER/PrintableString.php
+++ b/src/Pyrus/DER/PrintableString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Octet String
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class PrintableString extends String
 {
     const TAG = 0x13;

--- a/src/Pyrus/DER/Schema.php
+++ b/src/Pyrus/DER/Schema.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IASN.1 schema
  *
@@ -24,7 +26,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Schema extends \Pyrus\DER
 {
     static protected $types = array();

--- a/src/Pyrus/DER/SchemaChoice.php
+++ b/src/Pyrus/DER/SchemaChoice.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IASN.1 schema Choice
  *
@@ -24,7 +26,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class SchemaChoice extends Schema
 {
     protected $options = array();

--- a/src/Pyrus/DER/Sequence.php
+++ b/src/Pyrus/DER/Sequence.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Sequence
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Sequence extends Constructed
 {
     const TAG = 0x30;

--- a/src/Pyrus/DER/Set.php
+++ b/src/Pyrus/DER/Set.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Set
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class Set extends Constructed
 {
     const TAG = 0x31;

--- a/src/Pyrus/DER/String.php
+++ b/src/Pyrus/DER/String.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule IA5String
  * 
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 abstract class String extends \Pyrus\DER
 {
     protected $value;

--- a/src/Pyrus/DER/UTCTime.php
+++ b/src/Pyrus/DER/UTCTime.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule UTC Time
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class UTCTime extends \Pyrus\DER
 {
     const TAG = 0x17;

--- a/src/Pyrus/DER/UTF8String.php
+++ b/src/Pyrus/DER/UTF8String.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule UTF8String
  *
@@ -24,7 +26,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class UTF8String extends String
 {
     const TAG = 0x0C;

--- a/src/Pyrus/DER/UniversalString.php
+++ b/src/Pyrus/DER/UniversalString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule UniversalString
  *
@@ -24,7 +26,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class UniversalString extends String
 {
     const TAG = 0x1C;

--- a/src/Pyrus/DER/VisibleString.php
+++ b/src/Pyrus/DER/VisibleString.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DER;
+
 /**
  * Represents a Distinguished Encoding Rule Octet String
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DER;
 class VisibleString extends String
 {
     const TAG = 0x1A;

--- a/src/Pyrus/Dependency/Exception.php
+++ b/src/Pyrus/Dependency/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Dependency;
+
 /**
  * Exception for dependencies
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Dependency;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/DirectedGraph.php
+++ b/src/Pyrus/DirectedGraph.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Implements a graph data type, used for topological sorting of packages.
  *
@@ -25,7 +27,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class DirectedGraph implements \Iterator
 {
     const WHITE = 0;

--- a/src/Pyrus/DirectedGraph/Exception.php
+++ b/src/Pyrus/DirectedGraph/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DirectedGraph;
+
 /**
  * Exception for directedgraph
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DirectedGraph;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/DirectedGraph/Vertex.php
+++ b/src/Pyrus/DirectedGraph/Vertex.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\DirectedGraph;
+
 /**
  * Class to represent vertices within the dependency directed graph.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\DirectedGraph;
 class Vertex implements \ArrayAccess, \Countable, \Iterator
 {
     const WHITE = \Pyrus\DirectedGraph::WHITE;

--- a/src/Pyrus/DownloadProgressListener.php
+++ b/src/Pyrus/DownloadProgressListener.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * This PEAR2_HTTP_Request listener implements a download progress bar
  *
@@ -22,8 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-
-namespace Pyrus;
 class DownloadProgressListener extends \PEAR2\HTTP\Request\Listener
 {
     protected $filesize;

--- a/src/Pyrus/Exception.php
+++ b/src/Pyrus/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base Exception class for Pyrus.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/FileTransactions.php
+++ b/src/Pyrus/FileTransactions.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base class for Pyrus.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class FileTransactions
 {
     private $fileOperations = array();

--- a/src/Pyrus/HTTPException.php
+++ b/src/Pyrus/HTTPException.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Exception for HTTP issues
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class HTTPException extends \PEAR2\Exception {}

--- a/src/Pyrus/Installer.php
+++ b/src/Pyrus/Installer.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Pyrus Installer class
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Installer
 {
     /**

--- a/src/Pyrus/Installer/Exception.php
+++ b/src/Pyrus/Installer/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer;
+
 /**
  * Exception class for Pyrus installer
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Installer/Role/Cfg.php
+++ b/src/Pyrus/Installer/Role/Cfg.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * user-customizable configuration role
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Cfg extends \Pyrus\Installer\Role\Common
 {
     protected $md5 = null;

--- a/src/Pyrus/Installer/Role/Common.php
+++ b/src/Pyrus/Installer/Role/Common.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Base class for all installation roles.
  *
@@ -26,7 +28,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Common
 {
     /**

--- a/src/Pyrus/Installer/Role/Customcommand.php
+++ b/src/Pyrus/Installer/Role/Customcommand.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Custom task xml file role
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Customcommand extends \Pyrus\Installer\Role\Data
 {
     function validate(\Pyrus\PackageInterface $package, array $file)

--- a/src/Pyrus/Installer/Role/Customrole.php
+++ b/src/Pyrus/Installer/Role/Customrole.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Custom role xml file role
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Customrole extends \Pyrus\Installer\Role\Data
 {
     function validate(\Pyrus\PackageInterface $package, array $file)

--- a/src/Pyrus/Installer/Role/Customtask.php
+++ b/src/Pyrus/Installer/Role/Customtask.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Custom task xml file role
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Customtask extends \Pyrus\Installer\Role\Data
 {
     function validate(\Pyrus\PackageInterface $package, array $file)

--- a/src/Pyrus/Installer/Role/Data.php
+++ b/src/Pyrus/Installer/Role/Data.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Data role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Data extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Doc.php
+++ b/src/Pyrus/Installer/Role/Doc.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Doc role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Doc extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Exception.php
+++ b/src/Pyrus/Installer/Role/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Exception for roles
  * 
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Installer/Role/Ext.php
+++ b/src/Pyrus/Installer/Role/Ext.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Ext role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Ext extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Php.php
+++ b/src/Pyrus/Installer/Role/Php.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * php role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Php extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Script.php
+++ b/src/Pyrus/Installer/Role/Script.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Script role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Script extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Src.php
+++ b/src/Pyrus/Installer/Role/Src.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Src role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Src extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Test.php
+++ b/src/Pyrus/Installer/Role/Test.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * Test role
  *
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Test extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Installer/Role/Www.php
+++ b/src/Pyrus/Installer/Role/Www.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Installer\Role;
+
 /**
  * www role
  * 
@@ -22,6 +24,5 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Installer\Role;
 class Www extends \Pyrus\Installer\Role\Common {}
 ?>

--- a/src/Pyrus/Logger.php
+++ b/src/Pyrus/Logger.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Standard logging class for Pyrus
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Logger
 {
     static public $log = array();

--- a/src/Pyrus/Main.php
+++ b/src/Pyrus/Main.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base class for Pyrus.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Main
 {
     const VERSION = '@PACKAGE_VERSION@';

--- a/src/Pyrus/OSGuess.php
+++ b/src/Pyrus/OSGuess.php
@@ -76,6 +76,8 @@
  * - define endianness, to allow matchSignature("bigend") etc.
  */
 
+namespace Pyrus;
+
 /**
  * Retrieves information about the current operating system
  *
@@ -91,7 +93,6 @@
  * @link       http://pear.php.net/package/PEAR
  * @since      Class available since Release 0.1
  */
-namespace Pyrus;
 class OSGuess
 {
     var $sysname;

--- a/src/Pyrus/PECLBuild.php
+++ b/src/Pyrus/PECLBuild.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Class handling building of PECL packages
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class PECLBuild
 {
     protected $ui;

--- a/src/Pyrus/PECLBuild/Exception.php
+++ b/src/Pyrus/PECLBuild/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PECLBuild;
+
 /**
  * Exception for a Pyrus PECL package builder.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PECLBuild;
 class Exception extends \PEAR2\Exception
 {
 }

--- a/src/Pyrus/Package.php
+++ b/src/Pyrus/Package.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Abstract representation of a package
  *
@@ -29,7 +31,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Package implements \Pyrus\PackageInterface
 {
     /**

--- a/src/Pyrus/Package/Base.php
+++ b/src/Pyrus/Package/Base.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Base class for representing a package in Pyrus
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 abstract class Base implements \Pyrus\PackageInterface
 {
     protected $archive;

--- a/src/Pyrus/Package/Cloner.php
+++ b/src/Pyrus/Package/Cloner.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Class for cloning (exact copies with hash intact if possible) packages
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 class Cloner
 {
     protected $hash;

--- a/src/Pyrus/Package/Creator.php
+++ b/src/Pyrus/Package/Creator.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Create packages using provided renderers.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 class Creator
 {
     const VERSION = '@PACKAGE_VERSION@';

--- a/src/Pyrus/Package/Creator/Exception.php
+++ b/src/Pyrus/Package/Creator/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package\Creator;
+
 /**
  * Exception class for package creator
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package\Creator;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Package/Creator/TaskIterator.php
+++ b/src/Pyrus/Package/Creator/TaskIterator.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package\Creator;
+
 /**
  * Class which iterates over all the tasks to perform for package creation.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package\Creator;
 class TaskIterator extends \FilterIterator
 {
     private $_inner;

--- a/src/Pyrus/Package/Dependency/Set.php
+++ b/src/Pyrus/Package/Dependency/Set.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package\Dependency;
+
 /**
  * Implements a set of dependency trees, and manipulates the trees to combine
  * them into a unique set of package releases to download
@@ -27,7 +29,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package\Dependency;
 class Set
 {
     protected $packageTrees = array();

--- a/src/Pyrus/Package/Dependency/Set/Exception.php
+++ b/src/Pyrus/Package/Dependency/Set/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package\Dependency\Set;
+
 /**
  * Class to represent vertices within the dependency directed graph.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package\Dependency\Set;
 class Exception extends \PEAR2\Exception
 {
     

--- a/src/Pyrus/Package/Exception.php
+++ b/src/Pyrus/Package/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Exception class for Packages
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Package/InstalledException.php
+++ b/src/Pyrus/Package/InstalledException.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Exception class for installed packages
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 class InstalledException extends \Pyrus\Package\Exception {}

--- a/src/Pyrus/Package/Phar.php
+++ b/src/Pyrus/Package/Phar.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Class for phar packages
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 class Phar extends \Pyrus\Package\Base
 {
     static private $_tempfiles = array();

--- a/src/Pyrus/Package/Phar/Exception.php
+++ b/src/Pyrus/Package/Phar/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package\Phar;
+
 /**
  * Exception class for Phar packages
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package\Phar;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Package/Xml.php
+++ b/src/Pyrus/Package/Xml.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Package;
+
 /**
  * Package represented just by the package.xml file
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Package;
 class Xml extends \Pyrus\Package\Base
 {
     function __construct($package, \Pyrus\Package $parent, \Pyrus\PackageFile $info = null)

--- a/src/Pyrus/PackageFile.php
+++ b/src/Pyrus/PackageFile.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Base class for a PEAR2 package file
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class PackageFile implements PackageFileInterface
 {
     public $info;

--- a/src/Pyrus/PackageFile/Exception.php
+++ b/src/Pyrus/PackageFile/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile;
+
 /**
  * Exception class for PackageFile
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/Parser/v2.php
+++ b/src/Pyrus/PackageFile/Parser/v2.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\Parser;
+
 /**
  * Parser for package.xml version 2.0
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\Parser;
 class v2 extends \Pyrus\XMLParser
 {
     private $_inContents = false;

--- a/src/Pyrus/PackageFile/v2/BundledPackage.php
+++ b/src/Pyrus/PackageFile/v2/BundledPackage.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Represents bundled packages in a package.xml bundle package type
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class BundledPackage implements \ArrayAccess, \Countable, \Iterator
 {
     protected $info;

--- a/src/Pyrus/PackageFile/v2/Compatible/Exception.php
+++ b/src/Pyrus/PackageFile/v2/Compatible/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Compatible;
+
 /**
  * Exception class for compatiblility exceptions in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Compatible;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Configureoption/Exception.php
+++ b/src/Pyrus/PackageFile/v2/Configureoption/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Configureoption;
+
 /**
  * Exception class for file exceptions in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Configureoption;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Dependencies.php
+++ b/src/Pyrus/PackageFile/v2/Dependencies.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Manage dependencies
  *
@@ -85,7 +87,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class Dependencies implements \ArrayAccess, \Countable
 {
     protected $parent;

--- a/src/Pyrus/PackageFile/v2/Dependencies/Exception.php
+++ b/src/Pyrus/PackageFile/v2/Dependencies/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Dependencies;
+
 /**
  * Exception class for dependency exceptions in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Dependencies;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Developer.php
+++ b/src/Pyrus/PackageFile/v2/Developer.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Manage an individual maintainer in package.xml
  *
@@ -36,7 +38,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class Developer implements \ArrayAccess, \Iterator
 {
     protected $parent;

--- a/src/Pyrus/PackageFile/v2/Developer/Exception.php
+++ b/src/Pyrus/PackageFile/v2/Developer/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Developer;
+
 /**
  * Exception class for developer exceptions in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Developer;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Files.php
+++ b/src/Pyrus/PackageFile/v2/Files.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Represents the files within a package file
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class Files implements \ArrayAccess, \Iterator
 {
     protected $info;

--- a/src/Pyrus/PackageFile/v2/Files/Exception.php
+++ b/src/Pyrus/PackageFile/v2/Files/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Files;
+
 /**
  * Exception class for file exceptions in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Files;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Files/File.php
+++ b/src/Pyrus/PackageFile/v2/Files/File.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Files;
+
 /**
  * Class for manipulating a filelist's file contents
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Files;
 class File extends \ArrayObject
 {
     protected $pkg;

--- a/src/Pyrus/PackageFile/v2/License.php
+++ b/src/Pyrus/PackageFile/v2/License.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Represents the files within a package file
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class License implements \ArrayAccess
 {
     protected $parent;

--- a/src/Pyrus/PackageFile/v2/License/Exception.php
+++ b/src/Pyrus/PackageFile/v2/License/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\License;
+
 /**
  * Exception class for exceptions when handling package license.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\License;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Release.php
+++ b/src/Pyrus/PackageFile/v2/Release.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Manage a release in package.xml
  *
@@ -52,7 +54,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class Release implements \ArrayAccess, \Countable
 {
     private $_parent;

--- a/src/Pyrus/PackageFile/v2/Release/BinaryPackage.php
+++ b/src/Pyrus/PackageFile/v2/Release/BinaryPackage.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Release;
+
 /**
  * Represents a binarypackage tag in an extsrcrelease or zendextsrcrelease tag
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Release;
 class BinaryPackage implements \ArrayAccess, \Iterator, \Countable
 {
     protected $info;

--- a/src/Pyrus/PackageFile/v2/Release/Exception.php
+++ b/src/Pyrus/PackageFile/v2/Release/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Release;
+
 /**
  * Exception class for release info in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Release;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Release/InstallCondition.php
+++ b/src/Pyrus/PackageFile/v2/Release/InstallCondition.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\Release;
+
 /**
  * Manage a release's installation conditions in package.xml
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\Release;
 class InstallCondition implements \ArrayAccess
 {
     protected $parent;

--- a/src/Pyrus/PackageFile/v2/SimpleProperty.php
+++ b/src/Pyrus/PackageFile/v2/SimpleProperty.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Represents a simple array property like version or stability
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class SimpleProperty implements \ArrayAccess
 {
     protected $info;

--- a/src/Pyrus/PackageFile/v2/UsesRoleTask/Exception.php
+++ b/src/Pyrus/PackageFile/v2/UsesRoleTask/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2\UsesRoleTask;
+
 /**
  * Exception class for compatiblility exceptions in a package file.
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2\UsesRoleTask;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/PackageFile/v2/Validator.php
+++ b/src/Pyrus/PackageFile/v2/Validator.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2;
+
 /**
  * Private validation class used by \Pyrus\PackageFile\v2 - do not use directly, its
  * sole purpose is to split up the PEAR/PackageFile/v2.php file to make it smaller
@@ -24,7 +26,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2;
 class Validator
 {
     const VERSION = '@PACKAGE_VERSION@';

--- a/src/Pyrus/PackageFile/v2Iterator/File.php
+++ b/src/Pyrus/PackageFile/v2Iterator/File.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * Traverse the complete <contents> tag, one <dir> at a time
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class File extends \RecursiveIteratorIterator
 {
     function next()

--- a/src/Pyrus/PackageFile/v2Iterator/FileAttribsFilter.php
+++ b/src/Pyrus/PackageFile/v2Iterator/FileAttribsFilter.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * Filter out the attributes meta-information when traversing the file list
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class FileAttribsFilter extends \RecursiveFilterIterator
 {
     function accept()

--- a/src/Pyrus/PackageFile/v2Iterator/FileContents.php
+++ b/src/Pyrus/PackageFile/v2Iterator/FileContents.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * Traverse the current <dir> in the <contents> tag
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class FileContents extends \RecursiveArrayIterator
 {
     protected $tag;

--- a/src/Pyrus/PackageFile/v2Iterator/FileContentsMulti.php
+++ b/src/Pyrus/PackageFile/v2Iterator/FileContentsMulti.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * iterator for tags with multiple sub-tags
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class FileContentsMulti extends FileContents
 {
     function key()

--- a/src/Pyrus/PackageFile/v2Iterator/FileInstallationFilter.php
+++ b/src/Pyrus/PackageFile/v2Iterator/FileInstallationFilter.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * filtered iterator for file installation
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class FileInstallationFilter extends \FilterIterator
 {
     static private $_parent;

--- a/src/Pyrus/PackageFile/v2Iterator/FileTag.php
+++ b/src/Pyrus/PackageFile/v2Iterator/FileTag.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * Store the path to the current file recursively
  *
@@ -28,7 +30,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class FileTag extends \ArrayObject
 {
     public $dir;

--- a/src/Pyrus/PackageFile/v2Iterator/MinimalPackageFilter.php
+++ b/src/Pyrus/PackageFile/v2Iterator/MinimalPackageFilter.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * packaging filter for generating a package without any role=test or role=doc
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class MinimalPackageFilter extends PackagingFilterBase
 {
     function accept()

--- a/src/Pyrus/PackageFile/v2Iterator/PackagingFilterBase.php
+++ b/src/Pyrus/PackageFile/v2Iterator/PackagingFilterBase.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * base class for filtering packaging contents to modify the files used from
  * a package.
@@ -23,7 +25,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 abstract class PackagingFilterBase extends \FilterIterator
 {
     function __construct(PackagingIterator $iterator)

--- a/src/Pyrus/PackageFile/v2Iterator/PackagingIterator.php
+++ b/src/Pyrus/PackageFile/v2Iterator/PackagingIterator.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * iterator for packaging
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class PackagingIterator extends \ArrayIterator
 {
     static private $_parent;

--- a/src/Pyrus/PackageFile/v2Iterator/ScriptFileFilterIterator.php
+++ b/src/Pyrus/PackageFile/v2Iterator/ScriptFileFilterIterator.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PackageFile\v2Iterator;
+
 /**
  * Class which iterates over all files, only returning those that contain script tasks.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PackageFile\v2Iterator;
 class ScriptFileFilterIterator extends \FilterIterator
 {
     private $_inner;

--- a/src/Pyrus/PluginRegistry.php
+++ b/src/Pyrus/PluginRegistry.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Registry manager for Pyrus plugins
  *
@@ -25,7 +27,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class PluginRegistry extends \Pyrus\Registry
 {
     protected $path;

--- a/src/Pyrus/PluginRegistry/Exception.php
+++ b/src/Pyrus/PluginRegistry/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\PluginRegistry;
+
 /**
  * Exception for a Pyrus PECL package builder.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\PluginRegistry;
 class Exception extends \PEAR2\Exception
 {
 }

--- a/src/Pyrus/REST.php
+++ b/src/Pyrus/REST.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Intelligently retrieve data, following hyperlinks if necessary, and re-directing
  * as well
@@ -23,7 +25,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class REST
 {
     protected $config;

--- a/src/Pyrus/REST/Exception.php
+++ b/src/Pyrus/REST/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\REST;
+
 /**
  * Exception class for REST
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\REST;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Registry.php
+++ b/src/Pyrus/Registry.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Registry manager
  *
@@ -29,8 +31,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
-
 class Registry implements \Pyrus\RegistryInterface, \IteratorAggregate
 {
     static protected $allRegistries = array();

--- a/src/Pyrus/Registry/Base.php
+++ b/src/Pyrus/Registry/Base.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Registry;
+
 /**
  * Base class for a Pyrus Registry
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Registry;
 abstract class Base implements \Pyrus\RegistryInterface
 {
     protected $packagename;

--- a/src/Pyrus/Registry/Exception.php
+++ b/src/Pyrus/Registry/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Registry;
+
 /**
  * Exception class for Pyrus Registry
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Registry;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Registry/Pear1/Package.php
+++ b/src/Pyrus/Registry/Pear1/Package.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Registry\Pear1;
+
 /**
  * Package within the PEAR 1.x registry
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Registry\Pear1;
 class Package extends \Pyrus\Registry\Package\Base
 {
     function fromPackageFile(\Pyrus\PackageFileInterface $package)

--- a/src/Pyrus/Registry/Sqlite3/Creator.php
+++ b/src/Pyrus/Registry/Sqlite3/Creator.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Registry\Sqlite3;
+
 /**
  * Initialize a sqlite3 registry
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Registry\Sqlite3;
 class Creator
 {
     /**

--- a/src/Pyrus/Registry/Sqlite3/Package.php
+++ b/src/Pyrus/Registry/Sqlite3/Package.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Registry\Sqlite3;
+
 /**
  * Package within the sqlite3 registry
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Registry\Sqlite3;
 class Package extends \Pyrus\Registry\Package\Base
 {
     public $dirty = false;

--- a/src/Pyrus/Registry/Xml/Package.php
+++ b/src/Pyrus/Registry/Xml/Package.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Registry\Xml;
+
 /**
  * Package within the xml registry
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Registry\Xml;
 class Package extends \Pyrus\Registry\Package\Base
 {
 }

--- a/src/Pyrus/ScriptFrontend.php
+++ b/src/Pyrus/ScriptFrontend.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * This class serves one purpose, removing the exit() call from displayUsage()
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class ScriptFrontend extends \PEAR2\Console\CommandLine
 {
     public function addCommand($name, $params = array(), $overrideOK = false)

--- a/src/Pyrus/ScriptFrontend/Command.php
+++ b/src/Pyrus/ScriptFrontend/Command.php
@@ -13,6 +13,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ScriptFrontend;
+
 /**
  * This class serves one purpose, removing the exit() call from displayUsage()
  *
@@ -23,8 +25,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-
-namespace Pyrus\ScriptFrontend;
 class Command extends \PEAR2\Console\CommandLine\Command
 {
     public $doc = '';

--- a/src/Pyrus/ScriptFrontend/Exception.php
+++ b/src/Pyrus/ScriptFrontend/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\ScriptFrontend;
+
 /**
  * Exception class for Pyrus Registry
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\ScriptFrontend;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/ScriptFrontend/Renderer.php
+++ b/src/Pyrus/ScriptFrontend/Renderer.php
@@ -20,6 +20,8 @@
  * @since     File available since release 0.1.0
  */
 
+namespace Pyrus\ScriptFrontend;
+
 /**
  * PEAR2_Console_CommandLine default renderer.
  *
@@ -32,7 +34,6 @@
  * @link      http://pear.php.net/package/Console_CommandLine
  * @since     Class available since release 0.1.0
  */
-namespace Pyrus\ScriptFrontend;
 class Renderer extends \PEAR2\Console\CommandLine\Renderer_Default
 {
     /**

--- a/src/Pyrus/ScriptRunner.php
+++ b/src/Pyrus/ScriptRunner.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Post-install script runner for Pyrus
  *
@@ -26,7 +28,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class ScriptRunner
 {
     protected $frontend;

--- a/src/Pyrus/Task/Common.php
+++ b/src/Pyrus/Task/Common.php
@@ -11,6 +11,8 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
+namespace Pyrus\Task;
+
 /**
  * A task is an operation that manipulates the contents of a file.
  *
@@ -40,7 +42,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task;
 abstract class Common extends \ArrayObject implements \SplSubject
 {
     static protected $customtasks = array();

--- a/src/Pyrus/Task/Exception.php
+++ b/src/Pyrus/Task/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task;
+
 /**
  * Exception class for Pyrus Tasks
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task;
 class Exception extends \PEAR2\Exception
 {
     /**#@+

--- a/src/Pyrus/Task/Exception/InvalidTask.php
+++ b/src/Pyrus/Task/Exception/InvalidTask.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task\Exception;
+
 /**
  * Exception class for Pyrus Tasks that are invalid for other reasons
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task\Exception;
 class InvalidTask extends \Pyrus\Task\Exception
 {
     function __construct($task, $file, $reason)

--- a/src/Pyrus/Task/Exception/MissingAttribute.php
+++ b/src/Pyrus/Task/Exception/MissingAttribute.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task\Exception;
+
 /**
  * Exception class for Pyrus Tasks that are invalid due to a missing attribute
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task\Exception;
 class MissingAttribute extends \PEAR2\Exception
 {
     function __construct($task, $attribute, $file)

--- a/src/Pyrus/Task/Exception/NoAttributes.php
+++ b/src/Pyrus/Task/Exception/NoAttributes.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task\Exception;
+
 /**
  * Exception class for Pyrus Tasks that are invalid because there are no attributes present
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task\Exception;
 class NoAttributes extends \PEAR2\Exception
 {
     function __construct($task, $file)

--- a/src/Pyrus/Task/Exception/WrongAttributeValue.php
+++ b/src/Pyrus/Task/Exception/WrongAttributeValue.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task\Exception;
+
 /**
  * Exception class for Pyrus Tasks that are invalid because the attribute value is invalid
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task\Exception;
 class WrongAttributeValue extends \PEAR2\Exception
 {
     function __construct($task, $attribute, $wrongvalue, $file, array $validvalues)

--- a/src/Pyrus/Task/MultipleProxy.php
+++ b/src/Pyrus/Task/MultipleProxy.php
@@ -11,6 +11,8 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
+namespace Pyrus\Task;
+
 /**
  * A container for multiple tasks
  *
@@ -23,7 +25,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task;
 class MultipleProxy extends \ArrayObject implements \IteratorAggregate, \SplObserver
 {
     protected $name;

--- a/src/Pyrus/Task/Postinstallscript/Paramgroup.php
+++ b/src/Pyrus/Task/Postinstallscript/Paramgroup.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task\Postinstallscript;
+
 /**
  * Implements the postinstallscript file task <paramgroup> tag
  *
@@ -30,7 +32,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task\Postinstallscript;
 class Paramgroup implements \ArrayAccess, \Iterator, \Countable
 {
     protected $info;

--- a/src/Pyrus/Task/Postinstallscript/Paramgroup/Param.php
+++ b/src/Pyrus/Task/Postinstallscript/Paramgroup/Param.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task\Postinstallscript\Paramgroup;
+
 /**
  * Implements the postinstallscript file task <param> tag
  *
@@ -30,7 +32,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task\Postinstallscript\Paramgroup;
 class Param implements \ArrayAccess, \Iterator, \Countable
 {
     protected $info;

--- a/src/Pyrus/Task/Replace.php
+++ b/src/Pyrus/Task/Replace.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task;
+
 /**
  * Implements the replace file task.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task;
 class Replace extends Common
 {
     const TYPE = 'simple';

--- a/src/Pyrus/Task/Unixeol.php
+++ b/src/Pyrus/Task/Unixeol.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task;
+
 /**
  * Implements the unix line endings file task.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task;
 class Unixeol extends \Pyrus\Task\Common
 {
     const TYPE = 'simple';

--- a/src/Pyrus/Task/Windowseol.php
+++ b/src/Pyrus/Task/Windowseol.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Task;
+
 /**
  * Implements the windows line endsings file task.
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Task;
 class Windowseol extends \Pyrus\Task\Common
 {
     const TYPE = 'simple';

--- a/src/Pyrus/Uninstaller.php
+++ b/src/Pyrus/Uninstaller.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Pyrus Uninstaller class
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Uninstaller
 {
     /**

--- a/src/Pyrus/Uninstaller/Exception.php
+++ b/src/Pyrus/Uninstaller/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Uninstaller;
+
 /**
  * Exception class for Pyrus uninstaller
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Uninstaller;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/Validate.php
+++ b/src/Pyrus/Validate.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Validation class for package.xml - channel-level advanced validation
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class Validate
 {
 /**#@+

--- a/src/Pyrus/Validate/Exception.php
+++ b/src/Pyrus/Validate/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Validate;
+
 /**
  * Exception class for Validate
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Validate;
 class Exception extends \PEAR2\Exception
 {
     /**

--- a/src/Pyrus/Validator/PECL.php
+++ b/src/Pyrus/Validator/PECL.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\Validator;
+
 /**
  * Channel Validator for the pecl.php.net channel
  *
@@ -22,7 +24,6 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\Validator;
 class PECL extends \Pyrus\Validate
 {
     function validateVersion()

--- a/src/Pyrus/XMLParser.php
+++ b/src/Pyrus/XMLParser.php
@@ -14,6 +14,8 @@
  * @link       https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Process an XML file, convert it to an array
  *
@@ -26,7 +28,6 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link       https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class XMLParser extends \XMLReader
 {
     /**

--- a/src/Pyrus/XMLParser/Exception.php
+++ b/src/Pyrus/XMLParser/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\XMLParser;
+
 /**
  * Exception class for the XMLParser
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\XMLParser;
 class Exception extends \PEAR2\Exception {}

--- a/src/Pyrus/XMLWriter.php
+++ b/src/Pyrus/XMLWriter.php
@@ -13,6 +13,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus;
+
 /**
  * Process an array, and serialize it into XML
  *
@@ -25,7 +27,6 @@
  * @license    http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link       https://github.com/pyrus/Pyrus
  */
-namespace Pyrus;
 class XMLWriter extends \XMLWriter
 {
     private $_array;

--- a/src/Pyrus/XMLWriter/Exception.php
+++ b/src/Pyrus/XMLWriter/Exception.php
@@ -12,6 +12,8 @@
  * @link      https://github.com/pyrus/Pyrus
  */
 
+namespace Pyrus\XMLWriter;
+
 /**
  * Exception class for the XMLWriter
  *
@@ -22,5 +24,4 @@
  * @license   http://www.opensource.org/licenses/bsd-license.php New BSD License
  * @link      https://github.com/pyrus/Pyrus
  */
-namespace Pyrus\XMLWriter;
 class Exception extends \PEAR2\Exception {}


### PR DESCRIPTION
When Pyrus migrated to using namespaces, most docblock comments ended up sticking to the namespace declaration. They should instead be right above the classes, not the namespaces.

This PR fixes that, hopefully providing some better IDE assistance in the process.
