### PR TITLE
Upgrade to PEAR2_HTTP_Request master with proxy fix

### DIFF
--- a/vendor/php/PEAR2/HTTP/Request/Adapter/Phpstream.php
+++ b/vendor/php/PEAR2/HTTP/Request/Adapter/Phpstream.php
@@ -34,9 +34,12 @@ class PhpStream extends Request\Adapter
     public function sendRequest()
     {
 
-        $proxyurl = '';
+        $proxyurl        = '';
+        $request_fulluri = false;
+
         if (!is_null($this->proxy)) {
-            $proxyurl = $this->proxy->url;
+            $proxyurl        = $this->proxy->url;
+            $request_fulluri = true;
         }
         $info = array(
                 $this->uri->protocol => array(
@@ -46,9 +49,11 @@ class PhpStream extends Request\Adapter
                     'proxy'  => $proxyurl,
                     'ignore_errors' => true,
                     'max_redirects' => 3,
+                    'request_fulluri' => $request_fulluri,
                 )
             );
         // create context with proper junk
+
         $ctx = stream_context_create(
             $info
         );
@@ -90,7 +95,6 @@ class PhpStream extends Request\Adapter
         foreach($headers as $line) {
             $this->processHeader($line);
         }
-
         return new Request\Response(
             $details,$body,new Request\Headers($this->headers),$this->cookies);
     }


### PR DESCRIPTION
The commit b69c1c34 which was to include v0.3.1 actually added v0.3.0

There is no v0.3.1 tag (in git), but the master branch of
PEAR2_HTTP_Request does include the fix for proxy support.

Master branch from PEAR2_HTTP_Request (https://github.com/pear2/HTTP_Request)
that is being added is at a877196f6e from 2012-02-21.

Signed-off-by: Paul Campbell paulcampbell@fife.ac.uk
